### PR TITLE
Bug: Jest asset imports failing

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,5 +3,7 @@ module.exports = {
   transform: {
     '^.+\\.ts$': 'ts-jest',
     '^.+\\.vue$': 'vue-jest',
+    '.+\\.(css|styl|less|sass|scss|png|jpg|svg|ttf|woff|woff2)$':
+      'jest-transform-stub',
   },
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint-plugin-vue": "^8.1.1",
     "husky": "^7.0.4",
     "jest": "^26.6.3",
+    "jest-transform-stub": "^2.0.0",
     "lint-staged": "^12.1.2",
     "prettier": "^2.5.0",
     "ts-jest": "^26.5.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3462,6 +3462,11 @@ jest-snapshot@^26.6.2:
     pretty-format "^26.6.2"
     semver "^7.3.2"
 
+jest-transform-stub@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/jest-transform-stub/-/jest-transform-stub-2.0.0.tgz#19018b0851f7568972147a5d60074b55f0225a7d"
+  integrity sha512-lspHaCRx/mBbnm3h4uMMS3R5aZzMwyNpNIJLXj4cEsV0mIUtS4IjYJLSoyjRCtnxb6RIGJ4NL2quZzfIeNhbkg==
+
 jest-util@^26.1.0, jest-util@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.6.2.tgz#907535dbe4d5a6cb4c47ac9b926f6af29576cbc1"


### PR DESCRIPTION
This change addresses the issue of jest encountering unexpected identifies/tokens when running on a vue component importing an asset such as for an image.